### PR TITLE
vKeyPair.java: fix a problem with genKeyPair if exponent is null

### DIFF
--- a/src/pro/javacard/vre/vKeyPair.java
+++ b/src/pro/javacard/vre/vKeyPair.java
@@ -29,7 +29,7 @@ public class vKeyPair {
 				KeyPairGenerator keyGen;
 				keyGen = KeyPairGenerator.getInstance("RSA", VRE.provider);
 				vRSAPublicKey vpubk = (vRSAPublicKey) pub;
-				if (vpubk.publicExponent != BigInteger.ZERO) {
+				if (vpubk.publicExponent != BigInteger.ZERO && vpubk.publicExponent != null ) {
 					keyGen.initialize(new RSAKeyGenParameterSpec(vpubk.getSize(), vpubk.publicExponent));
 				} else {
 					keyGen.initialize(vpubk.getSize());


### PR DESCRIPTION
reproduce:
kp = new KeyPair(KeyPair.ALG_RSA_CRT, KeyBuilder.LENGTH_RSA_1024);
kp.genKeyPair();
